### PR TITLE
Fix oracle semicolon syntax errors

### DIFF
--- a/src/main/java/os/db/evolve/DbEvolve.java
+++ b/src/main/java/os/db/evolve/DbEvolve.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -67,7 +66,7 @@ public class DbEvolve {
 
             boolean lock = dbLock.lock();
             if (!lock) {
-                logger.log(Level.INFO, "Db-Evolve skipping migration due to locked database.");
+                logger.log(Logger.Level.INFO, "Db-Evolve skipping migration due to locked database.");
                 return false;
             }
 
@@ -161,12 +160,11 @@ public class DbEvolve {
             parser.accept(line, lineNumber);
             if (parser.isComplete()) {
                 try {
-                    logger.log(Level.INFO, String.format("Executing migration %s: %s", toMigrate.getName(), parser.getStatement().replace("\n", "").replace("\r", "")));
-                    queryRunner.execute(connection, parser.getStatement());
+                    logger.log(Logger.Level.INFO, String.format("Executing migration %s: %s", toMigrate.getName(), parser.getStatement().replace("\n", "").replace("\r", "")));
+                    queryRunner.execute(connection, parser.getStatement().replace(';', ' ').trim());
                 } catch (SQLException e) {
                     throw new MigrationException(String.format("%s - Invalid sql statement found at line %d", toMigrate.getName(), parser.getStartLineNumber()), e);
                 }
-
                 parser.reset();
             }
 

--- a/src/main/java/os/db/evolve/LockRepository.java
+++ b/src/main/java/os/db/evolve/LockRepository.java
@@ -17,11 +17,11 @@ class LockRepository {
 
     void createTable() {
         try {
-            queryRunner.execute("CREATE TABLE DB_EVOLVE_LOCK (DB_LOCK INTEGER, TIMESTAMP TIMESTAMP, PRIMARY KEY (DB_LOCK));");
+            queryRunner.execute("CREATE TABLE DB_EVOLVE_LOCK (DB_LOCK INTEGER, TIMESTAMP TIMESTAMP, PRIMARY KEY (DB_LOCK))");
             queryRunner.executeUpdate("INSERT INTO DB_EVOLVE_LOCK (DB_LOCK,TIMESTAMP) VALUES (0, ?)", Timestamp.valueOf(LocalDateTime.now()));
         } catch (SQLException throwables) {
             // ignore => assumption table already exist. If not migration will fail anyway.
-            logger.log(Level.FINER, throwables.getMessage());
+            logger.log(Logger.Level.DEBUG, throwables.getMessage());
         }
     }
 

--- a/src/main/java/os/db/evolve/Logger.java
+++ b/src/main/java/os/db/evolve/Logger.java
@@ -1,15 +1,17 @@
 package os.db.evolve;
 
-import java.util.logging.Level;
 
 public interface Logger {
 
     default void log(Level level, String message) {
-        if (level == Level.SEVERE) {
+        if (level == Level.ERROR) {
             System.err.println("DbEvolve: " + message);
         } else {
             System.out.println("DbEvolve: " + message);
         }
 
+    }
+    enum Level {
+        DEBUG, INFO, ERROR
     }
 }

--- a/src/main/java/os/db/evolve/QueryRunner.java
+++ b/src/main/java/os/db/evolve/QueryRunner.java
@@ -24,9 +24,9 @@ class QueryRunner {
     }
 
     public void execute(Connection connection, String... sqlStatements) throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            for (String sqlStatement : sqlStatements) {
-                statement.execute(sqlStatement);
+        for (String sqlStatement : sqlStatements) {
+            try (Statement statement = connection.createStatement()) {
+                statement.executeUpdate(sqlStatement);
             }
         }
     }

--- a/src/main/java/os/db/evolve/SqlScriptRepository.java
+++ b/src/main/java/os/db/evolve/SqlScriptRepository.java
@@ -20,10 +20,10 @@ class SqlScriptRepository {
 
     void createTable() {
         try {
-            queryRunner.execute("CREATE TABLE DB_EVOLVE (name VARCHAR(255) NOT NULL, hash VARCHAR(64) NOT NULL, timestamp TIMESTAMP, PRIMARY KEY (name));");
+            queryRunner.execute("CREATE TABLE DB_EVOLVE (name VARCHAR(255) NOT NULL, hash VARCHAR(64) NOT NULL, timestamp TIMESTAMP, PRIMARY KEY (name))");
         } catch (SQLException throwables) {
             // ignore => assumption table already exist. If not migration will fail anyway.
-            logger.log(Level.FINER, throwables.getMessage());
+            logger.log(Logger.Level.DEBUG, throwables.getMessage());
             return;
         }
     }


### PR DESCRIPTION
Oracle JDBC Driver does not allow for statements to be ended with semicolons.